### PR TITLE
Added "timestamptz" to keywords regex

### DIFF
--- a/syntaxes/dbml.tmLanguage.json
+++ b/syntaxes/dbml.tmLanguage.json
@@ -64,7 +64,7 @@
     },
     "keywords": {
       "name": "keyword.dbml",
-      "match": "\\b(as|by|bool|boolean|bit|blob|decimal|double|enum|float|long|longblob|longtext|medium|mediumblob|mediumint|mediumtext|time|timestamp|tinyblob|tinyint|tinytext|text|bigint|int|int1|int2|int3|int4|int8|integer|float|float4|float8|double|char|varbinary|varchar|varcharacter|precision|date|datetime|year|unsigned|signed|numeric|ucase|lcase|mid|len|round|rank|now|format|coalesce|ifnull|isnull|nvl)\\b"
+      "match": "\\b(as|by|bool|boolean|bit|blob|decimal|double|enum|float|long|longblob|longtext|medium|mediumblob|mediumint|mediumtext|time|timestamp|timestamptz|tinyblob|tinyint|tinytext|text|bigint|int|int1|int2|int3|int4|int8|integer|float|float4|float8|double|char|varbinary|varchar|varcharacter|precision|date|datetime|year|unsigned|signed|numeric|ucase|lcase|mid|len|round|rank|now|format|coalesce|ifnull|isnull|nvl)\\b"
     },
     "comments": {
       "name": "comment.line.double-slash",


### PR DESCRIPTION
Added it as a keyword which is valid in PostgreSQL, to have proper syntax highlighting.

Ref:
- <https://www.postgresql.org/docs/12/datatype-datetime.html>